### PR TITLE
Fix windows path handling in fuzz whitelist

### DIFF
--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -180,12 +180,10 @@ fn fixture(file: &Path) -> Result<(), Box<dyn std::error::Error>> {
 
     // Whitelist lookup key – path relative to the fixtures root.
     let rel_path = file.strip_prefix("tests/fixtures/fuzz").unwrap_or(file);
-    let rel_str = rel_path
-        .to_string_lossy()
-        .replace('\\', "/");
+    let rel_str = rel_path.to_string_lossy().replace('\\', "/");
 
     let whitelist = load_whitelist();
-    let allowed = whitelist.get(rel_str.as_ref());
+    let allowed = whitelist.get::<str>(rel_str.as_ref());
 
     for (idx, schema_json) in schemas.iter().enumerate() {
         // Skip `false` schemas – they have an empty instance set by design.

--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -180,7 +180,9 @@ fn fixture(file: &Path) -> Result<(), Box<dyn std::error::Error>> {
 
     // Whitelist lookup key – path relative to the fixtures root.
     let rel_path = file.strip_prefix("tests/fixtures/fuzz").unwrap_or(file);
-    let rel_str = rel_path.to_string_lossy();
+    let rel_str = rel_path
+        .to_string_lossy()
+        .replace('\\', "/");
 
     let whitelist = load_whitelist();
     let allowed = whitelist.get(rel_str.as_ref());


### PR DESCRIPTION
## Summary
- normalize path separators before checking test whitelist

## Testing
- `cargo test --workspace --all-features --all-targets --locked` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6863ae05ec9c832096b8fe7c69ec93e6