### PR TITLE
Fix not schema generation in fuzzer

### DIFF
--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -34,7 +34,7 @@ fn load_whitelist() -> HashMap<String, HashSet<usize>> {
     );
     map.insert(
         "not.json".to_string(),
-        [2, 3, 4, 5, 8].iter().cloned().collect(),
+        [3, 4, 5, 8].iter().cloned().collect(),
     );
     map.insert(
         "if-then-else.json".to_string(),


### PR DESCRIPTION
## Summary
- generate simple values that always invalidate the `not` subschema
- remove the now passing whitelist entry for `not.json`

## Testing
- `just check`
- `cargo test fixture::not.json -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6864899bc95483208977f7f16e82b0db