### PR TITLE
Improve pattern fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "fancy-regex 0.12.0",
  "json_schema_ast",
  "rand",
+ "rand_regex",
  "serde_json",
  "url",
 ]
@@ -1046,6 +1047,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbd599a8c757f89100e3ae559fb1ef9efa1cfd9276136862e3089dec627b31"
+dependencies = [
+ "rand",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ rand = "0.8"
 serde_json = "1.0.135"
 json_schema_ast = { path = "../schema", version = "0.1.5-alpha.3" }
 fancy-regex = "0.12"
+rand_regex = "0.17"
 
 [dev-dependencies]
 url = "2.5.4"

--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -84,18 +84,12 @@ fn load_whitelist() -> HashMap<String, HashSet<usize>> {
     map.insert(
         "optional/ecmascript-regex.json".to_string(),
         [
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-            30, 31,
+            2, 3, 4, 6, 8, 11, 13, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
         ]
         .iter()
         .cloned()
         .collect(),
     );
-    map.insert(
-        "optional/non-bmp-regex.json".to_string(),
-        [0].iter().cloned().collect(),
-    );
-    map.insert("pattern.json".to_string(), [0, 1].iter().cloned().collect());
     map.insert(
         "optional/unknownKeyword.json".to_string(),
         [0].iter().cloned().collect(),


### PR DESCRIPTION
## Summary
- generate random strings matching simple regex patterns
- drop passing cases from regex whitelist

## Testing
- `just check`

------
https://chatgpt.com/codex/tasks/task_e_6864899bc95483208977f7f16e82b0db