### PR TITLE
[ci] fix compatibility CI coverage

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -17,6 +17,30 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Test golden-file compatibility CLI
+        run: |
+          cargo run --locked --bin jsoncompat -- ci tests/fixtures/cli/ci-old.json tests/fixtures/cli/ci-new.json --display json
+          if cargo run --locked --bin jsoncompat -- ci tests/fixtures/cli/ci-old.json tests/fixtures/cli/ci-incompatible.json --display json; then
+            echo "Expected incompatible golden files to fail" >&2
+            exit 1
+          fi
+
+      - name: Test JSON Schema compatibility CLI
+        run: |
+          cargo run --locked --bin jsoncompat -- compat tests/fixtures/backcompat/format_annotation_changed/old.json tests/fixtures/backcompat/format_annotation_changed/new.json --role both
+          if cargo run --locked --bin jsoncompat -- compat tests/fixtures/backcompat/type_change_string_number/old.json tests/fixtures/backcompat/type_change_string_number/new.json --role both; then
+            echo "Expected incompatible JSON Schemas to fail" >&2
+            exit 1
+          fi
+
+      - name: Test OpenAPI compatibility CLI
+        run: |
+          cargo run --locked --bin jsoncompat -- compat tests/fixtures/openapi_compat/request_anyof_optional_field_added/old.json tests/fixtures/openapi_compat/request_anyof_optional_field_added/new.json --openapi
+          if cargo run --locked --bin jsoncompat -- compat tests/fixtures/openapi_compat/operation_removed/old.json tests/fixtures/openapi_compat/operation_removed/new.json --openapi; then
+            echo "Expected incompatible OpenAPI documents to fail" >&2
+            exit 1
+          fi
+
       - name: Find merge base with main
         id: merge_base
         run: |
@@ -34,7 +58,7 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run jsoncompat ci
+      - name: Check stamp example schema compatibility
         if: steps.stamp_example.outputs.should_run == 'true'
         run: |
-          cargo run --bin jsoncompat ci examples/stamp/schema-v2.json examples/stamp/schema-v2.json.new
+          cargo run --locked --bin jsoncompat -- compat examples/stamp/schema-v2.json examples/stamp/schema-v2.json.new --role both

--- a/tests/fixtures/cli/ci-incompatible.json
+++ b/tests/fixtures/cli/ci-incompatible.json
@@ -1,0 +1,14 @@
+{
+  "profile": {
+    "mode": "serializer",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "integer" }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    "stable_id": "profile"
+  }
+}

--- a/tests/fixtures/cli/ci-new.json
+++ b/tests/fixtures/cli/ci-new.json
@@ -1,0 +1,14 @@
+{
+  "profile": {
+    "mode": "serializer",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    "stable_id": "profile"
+  }
+}

--- a/tests/fixtures/cli/ci-old.json
+++ b/tests/fixtures/cli/ci-old.json
@@ -1,0 +1,14 @@
+{
+  "profile": {
+    "mode": "serializer",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    "stable_id": "profile"
+  }
+}


### PR DESCRIPTION
## Summary

- use the raw JSON Schema `compat` command for the stamp example merge-base check
- add executable CLI smoke checks for golden files, raw JSON Schema, and OpenAPI
- cover both compatible and expected-incompatible outcomes for every interface

## Root cause

The compatibility workflow was migrated from the removed Pydantic golden-file example to a raw stamp schema, but it continued invoking `jsoncompat ci`. That subcommand expects a map of golden entries, so parsing a raw JSON Schema failed before compatibility analysis.

## Impact

Pull requests now exercise all three compatibility CLI surfaces and verify that incompatible inputs fail rather than allowing an accidental always-success regression. The stamp example remains guarded bidirectionally with `--role both`.

## Validation

- `just check`
- positive and expected-failure `jsoncompat ci` smoke paths
- positive and expected-failure raw JSON Schema `compat` smoke paths
- positive and expected-failure OpenAPI `compat --openapi` smoke paths
- `git diff --check`
