### PR TITLE
[codex] Speed up full test checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,14 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy (deny warnings)
-        run: cargo clippy --workspace --all-features --all-targets -- -D warnings
-
-      - name: cargo check
-        run: cargo check --workspace --all-features --all-targets --locked
+        run: cargo clippy --workspace --all-features --all-targets --locked -- -D warnings
 
       - name: cargo test
-        run: cargo test --workspace --all-features --all-targets --locked
+        run: cargo test --workspace --all-features --locked
+
+      - name: Smoke-check benchmarks
+        if: matrix.os == 'ubuntu-latest' && matrix.toolchain == 'stable'
+        run: cargo bench --workspace --all-features --bench '*' --locked -- --test
 
   python-linux:
     runs-on: ${{ matrix.platform.runner }}

--- a/Justfile
+++ b/Justfile
@@ -10,9 +10,8 @@ check:
   else \
     cargo build -p jsoncompat_py; \
   fi
-  cargo clippy --workspace --all-features --all-targets -- -D warnings
-  cargo check --workspace --all-features --all-targets --locked
-  cargo test --workspace --all-features --all-targets --locked
+  cargo clippy --workspace --all-features --all-targets --locked -- -D warnings
+  cargo test --workspace --all-features --locked
   @echo "[just] checking Python code …"
   env -u VIRTUAL_ENV uv run --project pybindings --with pyright==1.1.408 pyright
   @echo "[just] checking TypeScript code …"
@@ -24,11 +23,11 @@ regen-dataclasses-fixtures:
 
 bench:
   @echo "[just] running Rust benchmarks …"
-  cargo bench --benches
+  cargo bench --workspace --all-features --bench '*' --locked
 
 bench-check:
   @echo "[just] smoke-checking Rust benchmarks …"
-  cargo bench --benches -- --test
+  cargo bench --workspace --all-features --bench '*' --locked -- --test
 
 # ---- Basic python smoke test ----
 

--- a/tests/dataclasses_fixtures.rs
+++ b/tests/dataclasses_fixtures.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 
 #[path = "support/python_env.rs"]
 mod python_env;
@@ -35,6 +36,7 @@ fn dataclass_snapshots_are_up_to_date_for_all_sample_schemas() {
     snapshot_stamp_example(repo_root, update, &mut expected_paths);
 
     prune_or_validate_stale_snapshots(repo_root, update, &expected_paths);
+    assert_python_syntax(&expected_paths);
 }
 
 fn snapshot_backcompat_fixtures(
@@ -166,10 +168,6 @@ fn assert_snapshot(
         "dataclass snapshot is stale: {}. Run `just regen-dataclasses-fixtures`.",
         snapshot_path.display()
     );
-
-    if matches!(snapshot.kind, SnapshotKind::Python) {
-        assert_python_syntax(&snapshot_path);
-    }
 }
 
 fn normalized_newlines(contents: &str) -> String {
@@ -284,19 +282,30 @@ fn read_json(path: impl AsRef<Path>) -> Value {
     .unwrap_or_else(|error| panic!("parse json {}: {error}", path.as_ref().display()))
 }
 
-fn assert_python_syntax(path: &Path) {
-    let status = python_env::python_command()
+fn assert_python_syntax(expected_paths: &BTreeSet<PathBuf>) {
+    let python_paths = expected_paths
+        .iter()
+        .filter(|path| path.extension().and_then(|extension| extension.to_str()) == Some("py"))
+        .collect::<Vec<_>>();
+    let mut child = python_env::python_command()
         .arg("-B")
         .arg("-c")
         .arg(
-            "import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'), filename=sys.argv[1])",
+            "import ast, json, pathlib, sys\nfor raw_path in json.load(sys.stdin):\n    path = pathlib.Path(raw_path)\n    ast.parse(path.read_text(encoding='utf-8'), filename=str(path))",
         )
-        .arg(path)
-        .status()
-        .expect("run python syntax check");
+        .stdin(Stdio::piped())
+        .spawn()
+        .expect("start python syntax check");
+
+    serde_json::to_writer(
+        child.stdin.take().expect("python syntax check stdin"),
+        &python_paths,
+    )
+    .expect("write generated dataclass paths");
+
+    let status = child.wait().expect("run python syntax check");
     assert!(
         status.success(),
-        "generated dataclass fixture {} did not compile",
-        path.display()
+        "generated dataclass fixtures did not compile"
     );
 }


### PR DESCRIPTION
## Summary

- batch generated dataclass syntax checks into one Python interpreter
- remove the redundant Cargo check pass and keep routine tests focused on tests plus doctests
- smoke-check only the explicit Criterion benchmark targets on stable Linux CI

## Why

The dataclass snapshot test launched a fresh uv and Python process for each of 545 generated files. Batching those syntax checks reduced its warm runtime from about 24.7 seconds to 0.48 seconds.

The previous all-targets test command also executed Criterion benchmarks during every test run and skipped doctests. The new split keeps all-target Clippy coverage, runs ordinary tests and doctests normally, and executes the three benchmark harnesses once in CI.

## Validation

- just check
- just bench-check