### PR TITLE
[codex] fix wheel artifact uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check GitHub Actions workflows
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 # v1.7.12
+        with:
+          args: -color
+
   rust:
     name: ${{ matrix.os }} / ${{ matrix.toolchain }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: wheels-linux-${{ matrix.platform.target }}
-          path: python/dist
+          path: pybindings/dist
+          if-no-files-found: error
 
   python-musllinux:
     runs-on: ${{ matrix.platform.runner }}
@@ -106,7 +107,8 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
-          path: python/dist
+          path: pybindings/dist
+          if-no-files-found: error
 
   python-windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -130,7 +132,8 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: wheels-windows-${{ matrix.platform.target }}
-          path: python/dist
+          path: pybindings/dist
+          if-no-files-found: error
 
   python-macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -154,7 +157,8 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: wheels-macos-${{ matrix.platform.target }}
-          path: python/dist
+          path: pybindings/dist
+          if-no-files-found: error
 
   python-release:
     name: Release

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -45,7 +45,7 @@ jobs:
         id: merge_base
         run: |
           git fetch origin main
-          echo "MERGE_BASE=$(git merge-base HEAD origin/main)" >> $GITHUB_OUTPUT
+          echo "MERGE_BASE=$(git merge-base HEAD origin/main)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout stamp example schema from MERGE_BASE
         id: stamp_example


### PR DESCRIPTION
## Summary

- upload Python wheels from the `pybindings/dist` directory where maturin writes them
- fail wheel build jobs immediately when no files match the artifact path
- lint all GitHub Actions workflows with actionlint 1.7.12 in a dedicated CI job
- quote the existing `GITHUB_OUTPUT` redirection flagged by actionlint and ShellCheck

## Root cause

The wheel matrices built packages successfully under `pybindings/dist`, but their upload steps referenced `python/dist`. Because `upload-artifact` defaulted to warning when no files matched, those jobs passed without producing wheel artifacts. The release job then failed while trying to attest `wheels-*/*`.

## Impact

Future releases will provide wheel artifacts to the attestation and PyPI publication steps. A missing wheel output now fails in its producing matrix job with a direct error. Workflow syntax, expressions, action inputs, and embedded shell scripts are checked by actionlint on every push and pull request.

## Validation

- `just check`
- local actionlint 1.7.12 against all workflows
- GitHub-hosted `actionlint` job with ShellCheck integration
- `git diff --check`
- workflow YAML parse check